### PR TITLE
feat: google-ai → google 자동 마이그레이션 기능 구현

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -172,7 +172,20 @@ bun add @j-token/easy-opencode@latest
 
 - 지원 `providerId`: `provider.openai`, `provider["google-ai"]`
 
+### OpenAI OAuth 지원
+
+OpenAI OAuth 모델을 사용하려면 아래 플러그인을 반드시 설치해야 합니다:
+
+- **저장소**: [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)
+- **설정 방법** (`opencode.json`):
+  ```json
+  {
+    "plugin": ["opencode-openai-codex-auth@4.2.0"]
+  }
+  ```
+
 ### 내장 모델 프리셋
+
 
 아래 모델 키/이름을 내장 프리셋으로 추가합니다(실제 사용 가능 여부는 계정/키/지역 정책에 따라 달라질 수 있습니다).
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,20 @@ Running `npx @j-token/easy-opencode` (or `easy-opencode` if installed globally) 
 
 - Supported providerId: `provider.openai`, `provider["google-ai"]`
 
+### OpenAI OAuth Support
+
+To use OpenAI OAuth models, you must install the following plugin:
+
+- **Repository**: [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)
+- **Configuration** in `opencode.json`:
+  ```json
+  {
+    "plugin": ["opencode-openai-codex-auth@4.2.0"]
+  }
+  ```
+
 ### Built-in model presets
+
 
 The CLI also injects the following model keys/names via built-in presets (actual availability depends on your account, keys, and regional policies).
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Project config overrides user config.
 
 Running `npx @j-token/easy-opencode` (or `easy-opencode` if installed globally) merges built-in provider presets into `~/.config/opencode/opencode.jsonc` (preferred) or `~/.config/opencode/opencode.json`.
 
-- Supported providerId: `provider.openai`, `provider["google-ai"]`
+- Supported providerId: `provider.openai`, `provider.google`
+- Auto-migration: `provider["google-ai"]` → `provider.google` (0.2.3+)
 
 ### OpenAI OAuth Support
 
@@ -212,7 +213,7 @@ The CLI also injects the following model keys/names via built-in presets (actual
   - `gpt-5.1-medium`: GPT 5.1 Medium (OAuth)
   - `gpt-5.1-high`: GPT 5.1 High (OAuth)
 
-- Google AI Studio (`provider["google-ai"]`)
+- Google AI Studio (`provider.google`)
   - `gemini-3-pro-high`: Gemini 3 Pro High (`models/gemini-3-pro-preview`)
   - `gemini-3-pro-medium`: Gemini 3 Pro Medium (`models/gemini-3-pro-preview`)
   - `gemini-3-pro-low`: Gemini 3 Pro Low (`models/gemini-3-pro-preview`)
@@ -231,7 +232,7 @@ Options:
 
 - Plugin load: in OpenCode, call `lsp_servers` and confirm a server list is shown
 - CLI dry-run: `npx @j-token/easy-opencode --dry-run --on-conflict keep`
-- CLI apply: run `npx @j-token/easy-opencode --on-conflict keep`, then confirm `provider.openai` / `provider["google-ai"]` changed in `~/.config/opencode/opencode.jsonc` (preferred) or `~/.config/opencode/opencode.json`
+- CLI apply: run `npx @j-token/easy-opencode --on-conflict keep`, then confirm `provider.openai` / `provider.google` changed in `~/.config/opencode/opencode.jsonc` (preferred) or `~/.config/opencode/opencode.json`
 
 ## Safety
 

--- a/dev-docs/openai-oauth-plugin-info/plan.md
+++ b/dev-docs/openai-oauth-plugin-info/plan.md
@@ -1,0 +1,14 @@
+# OpenAI OAuth 플러그인 안내 추가 계획
+
+## 개요
+OpenAI OAuth 기능을 사용하기 위해 필요한 필수 플러그인(`opencode-openai-codex-auth`) 정보를 README에 추가합니다.
+
+## 작업 상세
+1. `README.md` (영문) 수정
+   - "Install" 또는 "OpenAI" 관련 섹션에 플러그인 설치 안내 추가
+   - 플러그인 저장소 링크 및 설치 방법(`plugin` 설정) 명시
+2. `README.ko.md` (국문) 수정
+   - 동일한 위치에 한국어 안내 추가
+3. 내용 검증
+   - 링크 작동 여부 확인 (전달받은 링크: https://github.com/numman-ali/opencode-openai-codex-auth)
+   - 설정 형식 확인 (`"plugin": ["opencode-openai-codex-auth@4.2.0"]`)

--- a/dev-docs/openai-oauth-plugin-info/spec.md
+++ b/dev-docs/openai-oauth-plugin-info/spec.md
@@ -1,0 +1,31 @@
+# OpenAI OAuth 플러그인 안내 추가 상세 스펙
+
+## 대상 파일
+- `README.md`
+- `README.ko.md`
+
+## 추가될 내용 (영문)
+### OpenAI OAuth Support
+To use OpenAI OAuth models, you must install the following plugin:
+- Repository: [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)
+- Configuration:
+  ```json
+  {
+    "plugin": ["opencode-openai-codex-auth@4.2.0"]
+  }
+  ```
+
+## 추가될 내용 (국문)
+### OpenAI OAuth 지원
+OpenAI OAuth 모델을 사용하려면 아래 플러그인을 반드시 설치해야 합니다:
+- 저장소: [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)
+- 설정 방법:
+  ```json
+  {
+    "plugin": ["opencode-openai-codex-auth@4.2.0"]
+  }
+  ```
+
+## 위치 선정
+- `## CLI (provider sync)` 섹션 아래 혹은 `## Install` 섹션의 하위 항목으로 추가하여 사용자가 OpenAI 모델 사용 전에 인지할 수 있도록 함.
+- 영문 버전에서는 `Built-in model presets` 시작 전에 추가하는 것이 적절해 보임.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,11 @@ async function main(): Promise<void> {
   let currentRaw = raw
   const migrationCheck = checkMigrationNeeded(provider)
 
+  // google와 google-ai가 동시에 있을 때의 마이그레이션 병합 정책
+  // - 기본은 keep(google 우선)
+  // - 사용자가 --on-conflict overwrite를 지정한 경우에만 overwrite로 동작
+  const migrationMode: ConflictMode = args.onConflict === "overwrite" ? "overwrite" : "keep"
+
   // 마이그레이션이 필요하거나 프리셋 병합이 필요한 경우 백업 생성
   // 백업은 모든 변경 전에 먼저 수행 (마이그레이션 전 원본 상태 보존)
   let backupPath: string | null = null
@@ -57,7 +62,7 @@ async function main(): Promise<void> {
 
   if (migrationCheck.needed) {
     // 마이그레이션 필요: 사용자 확인
-    const confirmed = await promptMigration(migrationCheck)
+    const confirmed = await promptMigration(migrationCheck, { onConflict: args.onConflict })
 
     if (confirmed) {
       // dry-run 모드: 마이그레이션 후 상태를 시뮬레이션
@@ -68,13 +73,14 @@ async function main(): Promise<void> {
         )
         // dry-run에서도 provider 상태를 마이그레이션 후 상태로 시뮬레이션
         // 이를 통해 이후 프리셋 diff 계산이 정확해짐
-        provider = simulateMigration(provider, migrationCheck)
+        provider = simulateMigration(provider, migrationCheck, migrationMode)
       } else {
         // 실제 마이그레이션 실행
         const migrationResult = await executeMigration({
           path,
           raw: currentRaw,
           checkResult: migrationCheck,
+          mode: migrationMode,
           dryRun: false,
         })
 
@@ -223,7 +229,7 @@ function printHelp(): void {
     "",
     "Options:",
     "  --dry-run          변경 요약만 출력하고 파일은 수정하지 않습니다.",
-    "  --on-conflict <m>   ask|overwrite|keep (기본 ask)",
+    "  --on-conflict <m>   ask|overwrite|keep (기본 ask, non-TTY에서 충돌 시 overwrite|keep 필요)",
     "  --no-backup         백업 파일을 생성하지 않습니다.",
     "  -h, --help          도움말 출력",
     "",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,10 +12,18 @@ import {
   backupOpenCodeConfig,
   writeProviderId,
 } from "./opencode-config"
+import {
+  checkMigrationNeeded,
+  promptMigration,
+  executeMigration,
+  formatMigrationMessage,
+  simulateMigration,
+} from "./migrate-provider"
 
 /**
  * npx @j-token/easy-opencode CLI
- * - ~/.config/opencode/opencode.jsonc(json)에서 provider(openai, google-ai)만 병합한다.
+ * - ~/.config/opencode/opencode.jsonc(json)에서 provider(openai, google)만 병합한다.
+ * - google-ai → google 마이그레이션을 자동으로 수행한다.
  * - 충돌은 providerId 단위로 1회만 묻는다.
  */
 async function main(): Promise<void> {
@@ -33,12 +41,71 @@ async function main(): Promise<void> {
 
   const { raw, data } = await readOpenCodeConfig(path)
 
-  const provider = (data && typeof data === "object" ? (data as any).provider : undefined) ?? {}
+  let provider = (data && typeof data === "object" ? (data as any).provider : undefined) ?? {}
 
-  const providerIds: ProviderId[] = ["openai", "google-ai"]
+  // google-ai → google 마이그레이션 체크 및 실행
+  let currentRaw = raw
+  const migrationCheck = checkMigrationNeeded(provider)
+
+  // 마이그레이션이 필요하거나 프리셋 병합이 필요한 경우 백업 생성
+  // 백업은 모든 변경 전에 먼저 수행 (마이그레이션 전 원본 상태 보존)
+  let backupPath: string | null = null
+  const needsBackup = !args.noBackup && !args.dryRun
+  if (needsBackup) {
+    backupPath = await backupOpenCodeConfig(path)
+  }
+
+  if (migrationCheck.needed) {
+    // 마이그레이션 필요: 사용자 확인
+    const confirmed = await promptMigration(migrationCheck)
+
+    if (confirmed) {
+      // dry-run 모드: 마이그레이션 후 상태를 시뮬레이션
+      if (args.dryRun) {
+        note(
+          `${pc.yellow("google-ai")} → ${pc.green("google")} 마이그레이션 예정`,
+          pc.cyan("dry-run migration")
+        )
+        // dry-run에서도 provider 상태를 마이그레이션 후 상태로 시뮬레이션
+        // 이를 통해 이후 프리셋 diff 계산이 정확해짐
+        provider = simulateMigration(provider, migrationCheck)
+      } else {
+        // 실제 마이그레이션 실행
+        const migrationResult = await executeMigration({
+          path,
+          raw: currentRaw,
+          checkResult: migrationCheck,
+          dryRun: false,
+        })
+
+        currentRaw = migrationResult.updatedRaw
+
+        // 마이그레이션 결과 메시지 표시
+        const migrationMessage = formatMigrationMessage(migrationResult)
+        if (migrationMessage) {
+          note(migrationMessage, pc.green("migration"))
+        }
+
+        // provider 객체 갱신 (마이그레이션 후 상태 반영)
+        const refreshed = await readOpenCodeConfig(path)
+        provider = (refreshed.data && typeof refreshed.data === "object"
+          ? (refreshed.data as any).provider
+          : undefined) ?? {}
+        currentRaw = refreshed.raw
+      }
+    } else {
+      cancel("마이그레이션이 취소되었습니다.")
+      process.exit(1)
+      return
+    }
+  }
+
+  // 프리셋 병합 대상 providerId (마이그레이션 후에는 google 사용)
+  const providerIds: ProviderId[] = ["openai", "google"]
 
   const planned: Array<{ providerId: ProviderId; mode: ConflictMode | "skip"; summary: ReturnType<typeof summarizeProviderDiff> }> = []
 
+  // 각 providerId에 대해 diff 계산 및 충돌 처리 방식 결정
   for (const providerId of providerIds) {
     const presetValue = (PROVIDER_PRESET as any)[providerId]
     const targetValue = provider[providerId]
@@ -67,6 +134,7 @@ async function main(): Promise<void> {
     return
   }
 
+  // dry-run 모드: 요약만 출력하고 종료
   if (args.dryRun) {
     for (const p of toApply) {
       note(formatSummaryLine(p.providerId, p.summary), pc.cyan("dry-run"))
@@ -75,12 +143,7 @@ async function main(): Promise<void> {
     return
   }
 
-  let backupPath: string | null = null
-  if (!args.noBackup) {
-    backupPath = await backupOpenCodeConfig(path)
-  }
-
-  let currentRaw = raw
+  // 프리셋 병합 실행
   for (const p of toApply) {
     const presetValue = (PROVIDER_PRESET as any)[p.providerId]
     const targetValue = provider[p.providerId]
@@ -165,7 +228,8 @@ function printHelp(): void {
     "  -h, --help          도움말 출력",
     "",
     "Scope:",
-    "  - provider.openai / provider.google-ai 만 병합합니다.",
+    "  - provider.openai / provider.google 만 병합합니다.",
+    "  - google-ai → google 자동 마이그레이션을 지원합니다.",
     "  - opencode.jsonc가 있으면 우선 수정합니다.",
   ]
 

--- a/src/cli/merge-provider.ts
+++ b/src/cli/merge-provider.ts
@@ -5,7 +5,7 @@
  * - 충돌 키만 overwrite/keep 한다.
  */
 
-export type ProviderId = "openai" | "google-ai"
+export type ProviderId = "openai" | "google"
 
 export type ConflictMode = "overwrite" | "keep"
 

--- a/src/cli/migrate-provider.ts
+++ b/src/cli/migrate-provider.ts
@@ -7,7 +7,7 @@
 import { confirm } from "@clack/prompts"
 import pc from "picocolors"
 
-import { mergeProviderId } from "./merge-provider"
+import { mergeProviderId, summarizeProviderDiff, type ConflictMode } from "./merge-provider"
 import { writeProviderId } from "./opencode-config"
 
 /**
@@ -38,6 +38,17 @@ export type MigrationResult = {
   googleAiDeleted: boolean
   /** 업데이트된 raw JSON 문자열 */
   updatedRaw: string
+}
+
+/**
+ * 마이그레이션 확인(prompt) 옵션
+ */
+export type MigrationPromptOptions = {
+  /**
+   * non-TTY 환경에서 자동 진행 여부를 판단하는 기준값
+   * - `overwrite|keep`이면 자동으로 진행 가능(=사용자가 비대화형 의도를 명시)
+   */
+  onConflict?: "ask" | "overwrite" | "keep"
 }
 
 /**
@@ -73,14 +84,39 @@ export function checkMigrationNeeded(provider: Record<string, unknown>): Migrati
 
 /**
  * 사용자에게 마이그레이션 확인을 요청한다.
- * - TTY가 아니면 에러를 발생시킨다.
+ * - TTY 환경에서는 사용자에게 확인을 받는다.
+ * - non-TTY 환경에서는 안전/명시 옵션 기준으로 자동 진행한다.
+ *   - google이 없으면 충돌이 없으므로 자동 진행
+ *   - google이 있어도 실제 충돌이 없으면 자동 진행(추가만 발생)
+ *   - 실제 충돌이 있으면 `--on-conflict overwrite|keep`가 필요
  * @param checkResult - 마이그레이션 체크 결과
- * @returns 사용자가 확인했으면 true, 취소했으면 false
+ * @param options - 프롬프트 동작 옵션
+ * @returns 진행하면 true, 취소/불가하면 false(또는 에러)
  */
-export async function promptMigration(checkResult: MigrationCheckResult): Promise<boolean> {
-  // non-TTY 환경에서는 대화형 진행이 불가능하다
+export async function promptMigration(
+  checkResult: MigrationCheckResult,
+  options: MigrationPromptOptions = {}
+): Promise<boolean> {
+  // non-TTY 환경에서는 대화형 진행이 불가능하다.
   if (!process.stdin.isTTY) {
-    throw new Error("Non-interactive terminal: migration requires user confirmation")
+    // google이 없으면 충돌 없이 옮길 수 있으므로 자동 진행한다.
+    if (!checkResult.hasGoogle) {
+      return true
+    }
+
+    // google도 있으면 충돌 가능성이 있으므로, 실제 충돌 여부를 먼저 판단한다.
+    // - 충돌이 없으면(추가만 발생) 프리셋 병합과 동일하게 자동 진행해도 안전하다.
+    const diff = summarizeProviderDiff(checkResult.googleValue, checkResult.googleAiValue)
+    if (diff.conflictCount === 0) {
+      return true
+    }
+
+    // 충돌이 있으면, 사용자 의도(비대화형)가 명시된 경우만 자동 진행한다.
+    if (options.onConflict === "overwrite" || options.onConflict === "keep") {
+      return true
+    }
+
+    throw new Error("Non-interactive terminal: use --on-conflict overwrite|keep to migrate google-ai when google exists")
   }
 
   const message = checkResult.hasGoogle
@@ -137,10 +173,12 @@ export async function executeMigration(args: {
   raw: string
   /** 마이그레이션 체크 결과 */
   checkResult: MigrationCheckResult
+  /** google와 google-ai가 동시에 있을 때의 충돌 처리 방식 */
+  mode?: ConflictMode
   /** dry-run 모드 여부 */
   dryRun: boolean
 }): Promise<MigrationResult> {
-  const { path, raw, checkResult, dryRun } = args
+  const { path, raw, checkResult, dryRun, mode = "keep" } = args
   const { hasGoogle, googleAiValue, googleValue } = checkResult
 
   // 병합된 값 계산
@@ -149,9 +187,9 @@ export async function executeMigration(args: {
   let mergedValue: unknown
 
   if (hasGoogle) {
-    // 둘 다 있는 경우: google 값 우선으로 병합 ("keep" 모드)
-    // google 값을 기준으로 google-ai의 고유 키만 추가
-    mergedValue = mergeProviderId(googleValue, googleAiValue, "keep")
+    // 둘 다 있는 경우: google을 기준(target)으로 google-ai를 병합(preset)한다.
+    // - 기본은 keep(google 우선) 이지만, mode로 overwrite/keep을 제어할 수 있다.
+    mergedValue = mergeProviderId(googleValue, googleAiValue, mode)
   } else {
     // google-ai만 있는 경우: google-ai 값을 그대로 사용
     mergedValue = googleAiValue
@@ -229,11 +267,13 @@ export function formatMigrationMessage(result: MigrationResult): string {
  * - 이를 통해 이후 프리셋 diff 계산이 정확해진다.
  * @param provider - 원본 provider 객체
  * @param checkResult - 마이그레이션 체크 결과
+ * @param mode - google와 google-ai가 동시에 있을 때의 충돌 처리 방식
  * @returns 마이그레이션 후 provider 객체 (시뮬레이션)
  */
 export function simulateMigration(
   provider: Record<string, unknown>,
-  checkResult: MigrationCheckResult
+  checkResult: MigrationCheckResult,
+  mode: ConflictMode = "keep"
 ): Record<string, unknown> {
   const { hasGoogle, googleAiValue, googleValue } = checkResult
 
@@ -241,8 +281,9 @@ export function simulateMigration(
   let mergedValue: unknown
 
   if (hasGoogle) {
-    // 둘 다 있는 경우: google 값 우선으로 병합
-    mergedValue = mergeProviderId(googleValue, googleAiValue, "keep")
+    // 둘 다 있는 경우: google을 기준(target)으로 google-ai를 병합(preset)한다.
+    // - 기본은 keep(google 우선) 이지만, mode로 overwrite/keep을 제어할 수 있다.
+    mergedValue = mergeProviderId(googleValue, googleAiValue, mode)
   } else {
     // google-ai만 있는 경우: google-ai 값을 그대로 사용
     mergedValue = googleAiValue

--- a/src/cli/migrate-provider.ts
+++ b/src/cli/migrate-provider.ts
@@ -1,0 +1,256 @@
+/**
+ * provider 마이그레이션 로직
+ * - google-ai → google으로 마이그레이션
+ * - 기존 사용자의 설정을 자동으로 이동
+ */
+
+import { confirm } from "@clack/prompts"
+import pc from "picocolors"
+
+import { mergeProviderId } from "./merge-provider"
+import { writeProviderId } from "./opencode-config"
+
+/**
+ * 마이그레이션 필요 여부를 확인하는 결과 타입
+ */
+export type MigrationCheckResult = {
+  /** 마이그레이션이 필요한지 여부 */
+  needed: boolean
+  /** google-ai 설정이 존재하는지 여부 */
+  hasGoogleAi: boolean
+  /** google 설정이 존재하는지 여부 */
+  hasGoogle: boolean
+  /** google-ai 설정 값 */
+  googleAiValue: unknown
+  /** google 설정 값 */
+  googleValue: unknown
+}
+
+/**
+ * 마이그레이션 실행 결과 타입
+ */
+export type MigrationResult = {
+  /** 마이그레이션이 실행되었는지 여부 */
+  executed: boolean
+  /** 마이그레이션 후 google 설정 값 */
+  mergedValue: unknown
+  /** google-ai가 삭제되었는지 여부 */
+  googleAiDeleted: boolean
+  /** 업데이트된 raw JSON 문자열 */
+  updatedRaw: string
+}
+
+/**
+ * 값이 유효한지 확인한다. (undefined와 null 모두 무효로 처리)
+ * @param value - 확인할 값
+ * @returns 유효한 값이면 true
+ */
+function isValidValue(value: unknown): boolean {
+  return value !== undefined && value !== null
+}
+
+/**
+ * 마이그레이션 필요 여부를 확인한다.
+ * @param provider - provider 객체 (설정 파일에서 읽어온 값)
+ * @returns 마이그레이션 필요 여부 및 관련 정보
+ */
+export function checkMigrationNeeded(provider: Record<string, unknown>): MigrationCheckResult {
+  const googleAiValue = provider["google-ai"]
+  const googleValue = provider["google"]
+
+  // null도 "존재하지 않음"으로 처리 (BUG FIX)
+  const hasGoogleAi = isValidValue(googleAiValue)
+  const hasGoogle = isValidValue(googleValue)
+
+  return {
+    needed: hasGoogleAi,
+    hasGoogleAi,
+    hasGoogle,
+    googleAiValue,
+    googleValue,
+  }
+}
+
+/**
+ * 사용자에게 마이그레이션 확인을 요청한다.
+ * - TTY가 아니면 에러를 발생시킨다.
+ * @param checkResult - 마이그레이션 체크 결과
+ * @returns 사용자가 확인했으면 true, 취소했으면 false
+ */
+export async function promptMigration(checkResult: MigrationCheckResult): Promise<boolean> {
+  // non-TTY 환경에서는 대화형 진행이 불가능하다
+  if (!process.stdin.isTTY) {
+    throw new Error("Non-interactive terminal: migration requires user confirmation")
+  }
+
+  const message = checkResult.hasGoogle
+    ? `${pc.yellow("google-ai")}와 ${pc.green("google")} 설정이 모두 존재합니다.\n두 설정을 병합하고 ${pc.yellow("google-ai")}를 ${pc.green("google")}으로 마이그레이션할까요?`
+    : `${pc.yellow("google-ai")} 설정이 발견되었습니다.\n${pc.green("google")}으로 마이그레이션할까요?`
+
+  const result = await confirm({
+    message,
+    initialValue: true,
+  })
+
+  // isCancel 체크
+  if (typeof result !== "boolean") {
+    return false
+  }
+
+  return result
+}
+
+/**
+ * 사용자에게 google-ai 키 삭제 확인을 요청한다.
+ * @returns 사용자가 삭제를 확인했으면 true, 아니면 false
+ */
+export async function promptDeleteOldKey(): Promise<boolean> {
+  // non-TTY 환경에서는 대화형 진행이 불가능하다
+  if (!process.stdin.isTTY) {
+    return false
+  }
+
+  const result = await confirm({
+    message: `기존 ${pc.yellow("google-ai")} 키를 삭제할까요?`,
+    initialValue: true,
+  })
+
+  // isCancel 체크
+  if (typeof result !== "boolean") {
+    return false
+  }
+
+  return result
+}
+
+/**
+ * 마이그레이션을 실행한다.
+ * - google-ai 값을 google으로 이동/병합한다.
+ * - 사용자 확인 후 google-ai 키를 삭제한다.
+ * @param args - 마이그레이션 실행에 필요한 인자
+ * @returns 마이그레이션 결과
+ */
+export async function executeMigration(args: {
+  /** 설정 파일 경로 */
+  path: string
+  /** 설정 파일 raw JSON 문자열 */
+  raw: string
+  /** 마이그레이션 체크 결과 */
+  checkResult: MigrationCheckResult
+  /** dry-run 모드 여부 */
+  dryRun: boolean
+}): Promise<MigrationResult> {
+  const { path, raw, checkResult, dryRun } = args
+  const { hasGoogle, googleAiValue, googleValue } = checkResult
+
+  // 병합된 값 계산
+  // - google만 있으면 google-ai 값을 그대로 사용
+  // - 둘 다 있으면 google 값 우선으로 병합
+  let mergedValue: unknown
+
+  if (hasGoogle) {
+    // 둘 다 있는 경우: google 값 우선으로 병합 ("keep" 모드)
+    // google 값을 기준으로 google-ai의 고유 키만 추가
+    mergedValue = mergeProviderId(googleValue, googleAiValue, "keep")
+  } else {
+    // google-ai만 있는 경우: google-ai 값을 그대로 사용
+    mergedValue = googleAiValue
+  }
+
+  // dry-run 모드면 실제 파일 수정 없이 반환
+  if (dryRun) {
+    return {
+      executed: true,
+      mergedValue,
+      googleAiDeleted: false,
+      updatedRaw: raw,
+    }
+  }
+
+  // google 키에 병합된 값 쓰기
+  let currentRaw = raw
+  const writeGoogleResult = await writeProviderId({
+    path,
+    raw: currentRaw,
+    providerId: "google",
+    providerValue: mergedValue,
+  })
+  currentRaw = writeGoogleResult.updatedRaw
+
+  // google-ai 키 삭제 확인
+  const shouldDelete = await promptDeleteOldKey()
+
+  if (shouldDelete) {
+    // google-ai 키 삭제 (undefined 전달)
+    const deleteResult = await writeProviderId({
+      path,
+      raw: currentRaw,
+      providerId: "google-ai",
+      providerValue: undefined,
+    })
+    currentRaw = deleteResult.updatedRaw
+
+    return {
+      executed: true,
+      mergedValue,
+      googleAiDeleted: true,
+      updatedRaw: currentRaw,
+    }
+  }
+
+  return {
+    executed: true,
+    mergedValue,
+    googleAiDeleted: false,
+    updatedRaw: currentRaw,
+  }
+}
+
+/**
+ * 마이그레이션 완료 메시지를 생성한다.
+ * @param result - 마이그레이션 결과
+ * @returns 완료 메시지 문자열
+ */
+export function formatMigrationMessage(result: MigrationResult): string {
+  if (!result.executed) {
+    return ""
+  }
+
+  const deleteMessage = result.googleAiDeleted
+    ? `, ${pc.yellow("google-ai")} 키 삭제됨`
+    : ""
+
+  return `${pc.yellow("google-ai")} → ${pc.green("google")} 마이그레이션 완료${deleteMessage}`
+}
+
+/**
+ * dry-run 모드에서 마이그레이션 후 provider 상태를 시뮬레이션한다.
+ * - 파일을 실제로 수정하지 않고 메모리에서만 마이그레이션 결과를 계산한다.
+ * - 이를 통해 이후 프리셋 diff 계산이 정확해진다.
+ * @param provider - 원본 provider 객체
+ * @param checkResult - 마이그레이션 체크 결과
+ * @returns 마이그레이션 후 provider 객체 (시뮬레이션)
+ */
+export function simulateMigration(
+  provider: Record<string, unknown>,
+  checkResult: MigrationCheckResult
+): Record<string, unknown> {
+  const { hasGoogle, googleAiValue, googleValue } = checkResult
+
+  // 병합된 값 계산
+  let mergedValue: unknown
+
+  if (hasGoogle) {
+    // 둘 다 있는 경우: google 값 우선으로 병합
+    mergedValue = mergeProviderId(googleValue, googleAiValue, "keep")
+  } else {
+    // google-ai만 있는 경우: google-ai 값을 그대로 사용
+    mergedValue = googleAiValue
+  }
+
+  // 시뮬레이션: google에 병합된 값 설정, google-ai는 유지 (삭제 확인 전이므로)
+  return {
+    ...provider,
+    google: mergedValue,
+  }
+}

--- a/src/cli/provider-preset.ts
+++ b/src/cli/provider-preset.ts
@@ -4,9 +4,9 @@
  * - npx CLI에서 ~/.config/opencode/opencode.json(c)의 provider에 병합한다.
  */
 export const PROVIDER_PRESET: {
-  openai: unknown
-  "google-ai": unknown
-  anthropic: unknown
+  openai: unknown;
+  google: unknown;
+  anthropic: unknown;
 } = {
   openai: {
     options: {
@@ -283,37 +283,35 @@ export const PROVIDER_PRESET: {
       },
     },
   },
-  "google-ai": {
-    npm: "@ai-sdk/google",
-    name: "Google AI Studio",
+  google: {
     models: {
       "gemini-3-pro-high": {
-        id: "models/gemini-3-pro-preview",
+        id: "gemini-3-pro-preview",
         name: "Gemini 3 Pro High",
         options: { thinkingLevel: "high", includeThoughts: true },
       },
       "gemini-3-pro-medium": {
-        id: "models/gemini-3-pro-preview",
+        id: "gemini-3-pro-preview",
         name: "Gemini 3 Pro Medium",
         options: { thinkingLevel: "medium", includeThoughts: true },
       },
       "gemini-3-pro-low": {
-        id: "models/gemini-3-pro-preview",
+        id: "gemini-3-pro-preview",
         name: "Gemini 3 Pro Low",
         options: { thinkingLevel: "low", includeThoughts: true },
       },
       "gemini-3-flash-high": {
-        id: "models/gemini-3-flash-preview",
+        id: "gemini-3-flash-preview",
         name: "Gemini 3 Flash High",
         options: { thinkingLevel: "high", includeThoughts: true },
       },
       "gemini-3-flash-medium": {
-        id: "models/gemini-3-flash-preview",
+        id: "gemini-3-flash-preview",
         name: "Gemini 3 Flash Medium",
         options: { thinkingLevel: "medium", includeThoughts: true },
       },
       "gemini-3-flash-low": {
-        id: "models/gemini-3-flash-preview",
+        id: "gemini-3-flash-preview",
         name: "Gemini 3 Flash Low",
         options: { thinkingLevel: "low", includeThoughts: true },
       },
@@ -337,4 +335,4 @@ export const PROVIDER_PRESET: {
       },
     },
   },
-}
+};

--- a/src/cli/provider-preset.ts
+++ b/src/cli/provider-preset.ts
@@ -1,6 +1,6 @@
 /**
  * easy-opencode 내장 provider 프리셋
- * - 대상: provider.openai / provider["google-ai"]
+ * - 대상: provider.openai / provider.google
  * - npx CLI에서 ~/.config/opencode/opencode.json(c)의 provider에 병합한다.
  */
 export const PROVIDER_PRESET: {

--- a/src/cli/provider-preset.ts
+++ b/src/cli/provider-preset.ts
@@ -286,32 +286,32 @@ export const PROVIDER_PRESET: {
   google: {
     models: {
       "gemini-3-pro-high": {
-        id: "gemini-3-pro-preview",
+        id: "models/gemini-3-pro-preview",
         name: "Gemini 3 Pro High",
         options: { thinkingLevel: "high", includeThoughts: true },
       },
       "gemini-3-pro-medium": {
-        id: "gemini-3-pro-preview",
+        id: "models/gemini-3-pro-preview",
         name: "Gemini 3 Pro Medium",
         options: { thinkingLevel: "medium", includeThoughts: true },
       },
       "gemini-3-pro-low": {
-        id: "gemini-3-pro-preview",
+        id: "models/gemini-3-pro-preview",
         name: "Gemini 3 Pro Low",
         options: { thinkingLevel: "low", includeThoughts: true },
       },
       "gemini-3-flash-high": {
-        id: "gemini-3-flash-preview",
+        id: "models/gemini-3-flash-preview",
         name: "Gemini 3 Flash High",
         options: { thinkingLevel: "high", includeThoughts: true },
       },
       "gemini-3-flash-medium": {
-        id: "gemini-3-flash-preview",
+        id: "models/gemini-3-flash-preview",
         name: "Gemini 3 Flash Medium",
         options: { thinkingLevel: "medium", includeThoughts: true },
       },
       "gemini-3-flash-low": {
-        id: "gemini-3-flash-preview",
+        id: "models/gemini-3-flash-preview",
         name: "Gemini 3 Flash Low",
         options: { thinkingLevel: "low", includeThoughts: true },
       },


### PR DESCRIPTION
- migrate-provider.ts 신규 생성: 마이그레이션 로직 구현
- ProviderId 타입을 'google-ai' → 'google'로 변경
- CLI 실행 시 google-ai 설정 자동 감지 및 마이그레이션 안내
- 백업 타이밍 개선: 마이그레이션 전 원본 상태 보존
- dry-run 모드에서 마이그레이션 시뮬레이션 지원
- null 값 처리 버그 수정